### PR TITLE
adds system requirements to readme & a note

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # CIPDocker
 Dockerfile for Chest Imaging Platform
+
+## System Requirements
+
+- Docker (https://docs.docker.com/engine/install/)
+- Python 2
+- Python pandas library
+
+## Note
+
+The bash scripts are meant to be run _outside_ the docker container, using docker's volume functionality to load files into the docker runtime container.

--- a/cip_vascular_analysis.sh
+++ b/cip_vascular_analysis.sh
@@ -22,6 +22,12 @@ $dock cp /host/${cid}.nrrd /tmp/${cid}.nrrd
 
 z_size=`$dock unu head ${cid}.nrrd | grep sizes | cut -d" " -f4`
 spacing=`$dock unu head ${cid}.nrrd | grep directions | cut -d, -f7 | cut -d\) -f1`
+
+if [ "$spacing" -eq "0" ]; then
+   echo "invalid DICOM data; spacing is 0";
+   exit;
+fi
+
 down=`awk "BEGIN {print ${spacing}/2}"`
 up=`awk "BEGIN {print 2/${spacing}}"`
 


### PR DESCRIPTION
Slightly improves error messaging, hopefully helping user craft correct DICOM data. Also exits program rather than continuing long output. _Before_ and _After_ terminal output below:

## Before

```
$ bash cip_vascular_analysis.sh DICOM /Users/user/Documents/my_path/host
Getting file names...
Reading DICOM header information...
Modality: CT
Getting file names...
Reading DICOM image...
Writing converted image...
DONE.
awk: division by zero
 source line number 1
unu resample: error resampling nrrd:
[nrrd] nrrdResampleExecute: trouble resampling
[nrrd] _nrrdResampleVectorAllocateUpdate: need at least 1 output samples (not 0) for cell-centered sampling along axis 2
Traceback (most recent call last):
  File "/ChestImagingPlatform/cip_python/dcnn/projects/lung_segmenter/lung_segmenter_dcnn.py", line 376, in <module>
    N_subsampling = int(op.n_subsampling))
  File "/ChestImagingPlatform/cip_python/dcnn/projects/lung_segmenter/lung_segmenter_dcnn.py", line 175, in execute
    image_sitk = sitk.ReadImage(input_ct)
  File "/root/miniconda2/lib/python2.7/site-packages/SimpleITK/SimpleITK.py", line 8876, in ReadImage
    return _SimpleITK.ReadImage(*args)
RuntimeError: Exception thrown in SimpleITK ReadImage: ../../Code/IO/src/sitkImageReaderBase.cxx:99:
sitk::ERROR: The file "/tmp/DICOM_resampled.nrrd" does not exist.
unu resample: error parsing "/tmp/DICOM_partialLungLabelMap_resampled.nrrd" as nrrd for -i,--input option:
[nrrd] nrrdLoad: fopen("/tmp/DICOM_partialLungLabelMap_resampled.nrrd","rb") failed: No such file or directory


Usage: unu resample [-old] -s,--size <sz0 ...> [-off,--offset [<off0 ...>]] \
       [-min,--minimum [<min0 ...>]] [-max,--maximum [<max0 ...>]] \
       [-k,--kernel <kern>] [-nrn] [-ne,--nonexistent <behavior>] \
       [-b,--boundary <behavior>] [-v,--value <value>] [-t,--type <type>] \
       [-cheap] [-c,--center <center>] [-co,--center-override] [-verbose <v>] \
       [-i,--input <nin>] [-o,--output <nout>]

             -old = instead of using the new nrrdResampleContext
                    implementation, use the old nrrdSpatialResample
                    implementation
     -s <sz0 ...> , --size <sz0 ...> = For each axis, information about how
                    many samples in output:
                  o "=": leave this axis completely untouched: no
                    resampling whatsoever
                  o "x<float>": multiply the number of input samples by
....
```

## After

```
$ bash cip_vascular_analysis.sh DICOM /Users/user/Documents/my_path/host
Getting file names...
Reading DICOM header information...
Modality: CT
Getting file names...
Reading DICOM image...
Writing converted image...
DONE.
invalid DICOM data; spacing is 0
```